### PR TITLE
Memory crash fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cocoa-websocket"]
 	path = cocoa-websocket
-	url = git://github.com/erichocean/cocoa-websocket.git
+	url = git://github.com/adamjernst/cocoa-websocket.git

--- a/SocketIoClient.h
+++ b/SocketIoClient.h
@@ -100,7 +100,7 @@ enum {
 
 /**
  * Called before socketIoClientDidDisconnect: if, and only if, the connection is 
- * closing due to a transport error. The domain of the error will be 
+ * closing due to a transport error or timeout. The domain of the error will be 
  * WebSocketErrorDomain or SocketIoClientErrorDomain.
  */
 - (void)socketIoClient:(SocketIoClient *)client didFailWithError:(NSError *)error;

--- a/SocketIoClient.h
+++ b/SocketIoClient.h
@@ -99,9 +99,13 @@ enum {
 - (void)socketIoClient:(SocketIoClient *)client didSendMessage:(NSString *)message isJSON:(BOOL)isJSON;
 
 /**
- * Called before socketIoClientDidDisconnect: if, and only if, the connection is 
- * closing due to a transport error or timeout. The domain of the error will be 
- * WebSocketErrorDomain or SocketIoClientErrorDomain.
+ * Called if a transport error or timeout occurs. If the socket was connected
+ * before the error, -isConnected will still return YES when this method is 
+ * called; disconnection will occur immediately afterwards, resulting in 
+ * socketIoClientDidDisconnect: being called *after* this delegate method.
+ * If the socket was not connected (i.e. it was connecting), 
+ * socketIoClientDidDisconnect: will not be called. The domain of the error 
+ * will be WebSocketErrorDomain or SocketIoClientErrorDomain.
  */
 - (void)socketIoClient:(SocketIoClient *)client didFailWithError:(NSError *)error;
 

--- a/SocketIoClient.m
+++ b/SocketIoClient.m
@@ -62,6 +62,8 @@ NSString *SocketIoClientErrorDomain = @"SocketIoClientErrorDomain";
 }
 
 - (void)checkIfConnected {
+  [self log:[NSString stringWithFormat:@"checkIfConnected, state is %d", [self state]]];
+  
   if ([self state] != SocketIoClientStateConnected) {
     // First close the socket, in case the client tries to immediately reconnect.
     // This will not dispatch any messages to the delegate (as documented) 
@@ -87,6 +89,7 @@ NSString *SocketIoClientErrorDomain = @"SocketIoClientErrorDomain";
     [_webSocket open];
     
     if (_connectTimeout > 0.0) {
+      [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(checkIfConnected) object:nil];
       [self performSelector:@selector(checkIfConnected) withObject:nil afterDelay:_connectTimeout];
     }
   }
@@ -246,6 +249,7 @@ NSString *SocketIoClientErrorDomain = @"SocketIoClientErrorDomain";
   // creating a new timer first (which retains self) and *then* invalidating 
   // the old one.
   
+  [self log:@"setTimeout resetting heartbeat timer"];
   NSTimer *t = [NSTimer scheduledTimerWithTimeInterval:_heartbeatTimeout
                                                target:self 
                                              selector:@selector(onTimeout) 
@@ -386,7 +390,9 @@ NSString *SocketIoClientErrorDomain = @"SocketIoClientErrorDomain";
 }
 
 - (void)log:(NSString *)message {
-  // NSLog(@"%@", message);
+#ifdef SOCKETIO_DEBUG
+  NSLog(@"%@: %@", self, message);
+#endif
 }
 
 @end

--- a/SocketIoClient.m
+++ b/SocketIoClient.m
@@ -250,8 +250,6 @@
   _isConnecting = NO;
   self.sessionId = nil;
   
-  [_queue removeAllObjects];
-  
   if (wasConnected && _delegate != nil) {
     [_delegate socketIoClientDidDisconnect:self];
   }

--- a/SocketIoClient.m
+++ b/SocketIoClient.m
@@ -9,7 +9,7 @@
 #import "SocketIoClient.h"
 #import "WebSocket.h"
 
-@interface SocketIoClient (FP_Private) <WebSocketDelegate>
+@interface SocketIoClient () <WebSocketDelegate>
 @property (nonatomic, retain, readwrite) NSString *sessionId;
 @property (nonatomic, readwrite) SocketIoClientState state;
 - (void)log:(NSString *)message;

--- a/SocketIoClient.m
+++ b/SocketIoClient.m
@@ -322,7 +322,7 @@ NSString *SocketIoClientErrorDomain = @"SocketIoClientErrorDomain";
 }
 
 - (void)onError:(NSError *)error {
-  if ([_delegate respondsToSelector:@selector(socketIoClient:didFailWithError:)]) {
+  if ([_delegate respondsToSelector:@selector(socketIoClient:didDisconnectWithError:)]) {
     [_delegate socketIoClient:self didDisconnectWithError:error];
   }
 }

--- a/SocketIoClient.m
+++ b/SocketIoClient.m
@@ -64,7 +64,7 @@ NSString *SocketIoClientErrorDomain = @"SocketIoClientErrorDomain";
 - (void)checkIfConnected {
   [self log:[NSString stringWithFormat:@"checkIfConnected, state is %d", [self state]]];
   
-  if ([self state] != SocketIoClientStateConnected) {
+  if ([self state] == SocketIoClientStateConnecting) {
     // First close the socket, in case the client tries to immediately reconnect.
     // This will not dispatch any messages to the delegate (as documented) 
     // since state is not Connected.
@@ -332,6 +332,7 @@ NSString *SocketIoClientErrorDomain = @"SocketIoClientErrorDomain";
 }
 
 - (void)onConnectError:(NSError *)error {
+  [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(checkIfConnected) object:nil];
   if ([_delegate respondsToSelector:@selector(socketIoClient:connectDidFailWithError:)]) {
     [_delegate socketIoClient:self connectDidFailWithError:error];
   }


### PR DESCRIPTION
Fix a memory management problem that could cause a crash if the heartbeat timer was the last retaining reference to self.
